### PR TITLE
Flag to avoid creating subdirectories in output directory

### DIFF
--- a/CHEWBBACA/allelecall/BBACA.py
+++ b/CHEWBBACA/allelecall/BBACA.py
@@ -226,7 +226,7 @@ def loci_translation(genesList, listOfGenomes2, verbose):
 
 # ================================================ MAIN ================================================ #
 
-def main(genomeFiles,genes,cpuToUse,gOutFile,BSRTresh,BlastpPath,forceContinue,jsonReport,verbose,forceReset,contained,chosenTaxon,chosenTrainingFile,inputCDS,sizeTresh):
+def main(genomeFiles,genes,cpuToUse,gOutFile,BSRTresh,BlastpPath,forceContinue,jsonReport,verbose,forceReset,contained,chosenTaxon,chosenTrainingFile,inputCDS,sizeTresh,noSubDir):
 
     #~ parser = argparse.ArgumentParser(description="This program call alleles for a set of genomes provided a schema")
     #~ parser.add_argument('-i', nargs='?', type=str, help='List of genome files (list of fasta files)', required=True)
@@ -246,6 +246,7 @@ def main(genomeFiles,genes,cpuToUse,gOutFile,BSRTresh,BlastpPath,forceContinue,j
     #~ parser.add_argument("--fr", help="force reset", required=False, action="store_true", default=False)
     #~ parser.add_argument("--contained", help=argparse.SUPPRESS, required=False, action="store_true", default=False)
     #~ parser.add_argument("--json", help="report in json file", required=False, action="store_true", default=False)
+    #~ parser.add_argument("--nosubdir", help="No subdirectories in ouput directory", required=False, action="store_true", default=False)
     #~
     #~ args = parser.parse_args()
     #~
@@ -688,8 +689,10 @@ def main(genomeFiles,genes,cpuToUse,gOutFile,BSRTresh,BlastpPath,forceContinue,j
 
         if not os.path.exists(gOutFile):
             os.makedirs(gOutFile)
-        # outputpath=os.path.dirname(gOutFile)
-        outputfolder = os.path.join(gOutFile, "results_" + str(time.strftime("%Y%m%dT%H%M%S")))
+        if(noSubDir):
+            outputpath = os.path.dirname(gOutFile)
+        else: 
+            outputfolder = os.path.join(gOutFile, "results_" + str(time.strftime("%Y%m%dT%H%M%S")))
         os.makedirs(outputfolder)
         print (statswrite)
         # ~ print

--- a/CHEWBBACA/allelecall/BBACA.py
+++ b/CHEWBBACA/allelecall/BBACA.py
@@ -690,7 +690,7 @@ def main(genomeFiles,genes,cpuToUse,gOutFile,BSRTresh,BlastpPath,forceContinue,j
         if not os.path.exists(gOutFile):
             os.makedirs(gOutFile)
         if(noSubDir):
-            outputpath = os.path.dirname(gOutFile)
+            outputfolder = os.path.dirname(gOutFile)
         else: 
             outputfolder = os.path.join(gOutFile, "results_" + str(time.strftime("%Y%m%dT%H%M%S")))
         os.makedirs(outputfolder)

--- a/CHEWBBACA/chewBBACA.py
+++ b/CHEWBBACA/chewBBACA.py
@@ -146,6 +146,7 @@ def allele_call():
     parser.add_argument("--fc", help="force continue", required=False, action="store_true", default=False)
     parser.add_argument("--fr", help="force reset", required=False, action="store_true", default=False)
     parser.add_argument("--json", help="report in json file", required=False, action="store_true", default=False)
+    parser.add_argument("--nosubdir", help="No subdirectories in ouput directory", required=False, action="store_true", default=False)
 
     args = parser.parse_args()
 
@@ -164,6 +165,7 @@ def allele_call():
     contained = args.contained
     inputCDS = args.CDS
     jsonReport = args.json
+    noSubDir = args.nosubdir
 
     genes2call = check_if_list_or_folder(genes)
 
@@ -211,7 +213,7 @@ def allele_call():
         genomes2call = "listGenomes2Call.txt"
 
     
-    BBACA.main(genomes2call,genes2call,cpuToUse,gOutFile,BSRTresh,BlastpPath,forceContinue,jsonReport,verbose,forceReset,contained,chosenTaxon,chosenTrainingFile,inputCDS,sizeTresh)
+    BBACA.main(genomes2call,genes2call,cpuToUse,gOutFile,BSRTresh,BlastpPath,forceContinue,jsonReport,verbose,forceReset,contained,chosenTaxon,chosenTrainingFile,inputCDS,sizeTresh,noSubDir)
 
 
     try:


### PR DESCRIPTION
Hello,

thanks for your great tool.
I am trying at the moment to implement in a MLST workflow and it would be nice to have a flag that does not allow creating subdirectories in the output directory and instead uses the given output path.
Do you think that is possible to add?

Best regards