### PR TITLE
AlleleCall - optimization for small datasets

### DIFF
--- a/CHEWBBACA/AlleleCall/AlleleCall.py
+++ b/CHEWBBACA/AlleleCall/AlleleCall.py
@@ -85,10 +85,6 @@ def create_hash_table(fasta_files, table_id, translation_table, output_directory
     return table_file
 
 
-# output_directory = pre_computed_dir
-# loci_files = schema_loci_fullpath
-# translation_table = config['Translation table']
-# cpu_cores = config['CPU cores']
 def speedup(output_directory, loci_files, translation_table, cpu_cores):
     """
     """
@@ -251,11 +247,6 @@ def count_classifications(classification_files):
     return [classification_counts, total_cds]
 
 
-# table_file = dna_tables[0]
-# presence_DNAhashtable = dna_distinct_htable
-# loci_files = im.invert_dictionary(loci_files)
-# classification_files = classification_files
-# input_ids = basename_inverse_map
 def dna_exact_matches(table_file, presence_DNAhashtable, loci_files, classification_files,
                       input_ids):
     """Find exact matches between input CDSs and alleles from a locus.
@@ -852,9 +843,6 @@ def create_unclassified_fasta(fasta_file, prot_file, unclassified_protids,
     fao.get_sequences_by_id(dna_index, unclassified_seqids, output_file)
 
 
-# classification_files = results['classification_files']
-# ns = ns
-# def assign_allele_ids(classification_files, ns):
 def assign_allele_ids(locus_files, ns):
     """Assign allele identifiers to coding sequences classified as EXC or INF.
 
@@ -873,7 +861,6 @@ def assign_allele_ids(locus_files, ns):
     """
     # assign allele identifiers
     novel_alleles = {}
-    #for locus, results in classification_files.items():
     # import allele calling results and sort to get INF first
     locus_results = fo.pickle_loader(locus_files[1])
     # sort by input order
@@ -1563,13 +1550,6 @@ def select_representatives(representative_candidates, locus, fasta_file,
     return [locus, selected]
 
 
-# fasta_files = input_files
-# schema_directory = schema_directory
-# temp_directory = temp_directory
-# loci_modes = loci_modes.copy()
-# loci_files = loci_to_call
-# config = config
-# pre_computed_dir = pre_computed_dir
 def allele_calling(fasta_files, schema_directory, temp_directory,
                    loci_modes, loci_files, config, pre_computed_dir):
     """
@@ -2279,29 +2259,6 @@ def allele_calling(fasta_files, schema_directory, temp_directory,
     return template_dict
 
 
-# input_file = '/home/rmamede/Desktop/rmamede/chewBBACA_development/ids.txt'
-# loci_list = '/home/rmamede/Desktop/rmamede/chewBBACA_development/genes.txt'
-# schema_directory = '/home/rmamede/Desktop/rmamede/chewBBACA_development/senterica_schema_optimized'
-# output_directory = '/home/rmamede/Desktop/rmamede/chewBBACA_development/test_optimized'
-# no_inferred = False
-# output_unclassified = False
-# output_missing = False
-# no_cleanup = True
-# hash_profiles = 'crc32'
-# ns = False
-# config = {'Minimum sequence length': 201,
-#           'Size threshold': 0.2,
-#           'Translation table': 11,
-#           'BLAST Score Ratio': 0.6,
-#           'Word size': 5,
-#           'Window size': 5,
-#           'Clustering similarity': 0.2,
-#           'Prodigal training file': '/home/rmamede/Desktop/rmamede/chewBBACA_development/senterica_schema_optimized/Salmonella_enterica.trn',
-#           'CPU cores': 6,
-#           'BLAST path': '/home/rmamede/.conda/envs/spyder/bin',
-#           'CDS input': False,
-#           'Prodigal mode': 'single',
-#           'Mode': 4}
 def main(input_file, loci_list, schema_directory, output_directory,
          no_inferred, output_unclassified, output_missing,
          no_cleanup, hash_profiles, ns, config):

--- a/CHEWBBACA/AlleleCall/AlleleCall.py
+++ b/CHEWBBACA/AlleleCall/AlleleCall.py
@@ -868,7 +868,6 @@ def assign_allele_ids(classification_files, ns):
                 if cds_hash in matched_alleles:
                     locus_results[genome_id].append(matched_alleles[cds_hash])
                 else:
-                    # possible to have EXC match to INF that was converted to NIPH
                     max_alleleid += 1
                     if ns is True:
                         locus_results[genome_id].append('INF-*{0}'.format(max_alleleid))
@@ -882,6 +881,9 @@ def assign_allele_ids(classification_files, ns):
                         novel_alleles.setdefault(locus, []).append([cds_hash, str(max_alleleid)])
 
                     # EXC to INF to enable accurate count of INF classifications
+                    # some INF classifications might be converted to NIPH based on similar
+                    # matches on the same genome. Matches to the new INF/NIPH will be
+                    # classified as EXC and need to be added as new alleles and converted to INF
                     if current_results[0] == 'EXC':
                         locus_results[genome_id][0] = 'INF'
 

--- a/CHEWBBACA/CreateSchema/CreateSchema.py
+++ b/CHEWBBACA/CreateSchema/CreateSchema.py
@@ -345,10 +345,11 @@ def create_schema_seed(fasta_files, output_directory, schema_name, ptf_path,
     fo.create_directory(clustering_dir)
 
     print('Clustering proteins...')
+    group_size = math.ceil(len(proteins)/40)
     cs_results = cf.cluster_sequences(proteins, word_size, window_size,
                                       clustering_sim, None, True,
                                       1, 1, clustering_dir, cpu_cores,
-                                      True, False)
+                                      group_size, False)
     print('\nClustered {0} proteins into {1} clusters.'
           ''.format(len(proteins), len(cs_results)))
 

--- a/CHEWBBACA/chewBBACA.py
+++ b/CHEWBBACA/chewBBACA.py
@@ -379,10 +379,6 @@ def allele_call():
                         choices=[1, 2, 3, 4], default=4,
                         help='')
 
-    parser.add_argument('--speedup', required=False,
-                        action='store_true', dest='speedup',
-                        help='')
-
     args = parser.parse_args()
 
     # determine if Prodigal is installed and in PATH
@@ -410,12 +406,6 @@ def allele_call():
         args.translation_table = run_params['translation_table']
         args.minimum_length = run_params['minimum_locus_length']
         args.size_threshold = run_params['size_threshold']
-
-    if args.speedup is True:
-        print('Creating directory with pre-computed data to speedup '
-              'allele calling. Ignoring other options.')
-        AlleleCall.speedup(args.schema_directory, args.translation_table,
-                           args.cpu_cores)
 
     # create output directory
     created = fo.create_directory(args.output_directory)
@@ -448,13 +438,23 @@ def allele_call():
     args.window_size = ct.WINDOW_SIZE_DEFAULT
     args.clustering_sim = ct.CLUSTERING_SIMILARITY_DEFAULT
 
-    ### convert this into AlleleCall.main(**vars(args))
-    AlleleCall.main(genome_list, loci_list, args.schema_directory, args.output_directory, args.ptf_path,
-                    args.blast_score_ratio, args.minimum_length, args.translation_table,
-                    args.size_threshold, args.word_size, args.window_size, args.clustering_sim,
-                    args.cpu_cores, args.blast_path, args.cds_input, args.prodigal_mode,
+    config = {'Minimum sequence length': args.minimum_length,
+              'Size threshold': args.size_threshold,
+              'Translation table': args.translation_table,
+              'BLAST Score Ratio': args.blast_score_ratio,
+              'Word size': args.word_size,
+              'Window size': args.window_size,
+              'Clustering similarity': args.clustering_sim,
+              'Prodigal training file': args.ptf_path,
+              'CPU cores': args.cpu_cores,
+              'BLAST path': args.blast_path,
+              'CDS input': args.cds_input,
+              'Prodigal mode': args.prodigal_mode,
+              'Mode': args.mode}
+
+    AlleleCall.main(genome_list, loci_list, args.schema_directory, args.output_directory,
                     args.no_inferred, args.output_unclassified, args.output_missing,
-                    args.no_cleanup, args.hash_profiles, args.mode, args.ns)
+                    args.no_cleanup, args.hash_profiles, args.ns, config)
 
     # if args.store_profiles is True:
     #     updated = ps.store_allelecall_results(args.output_directory, args.schema_directory)

--- a/CHEWBBACA/chewBBACA.py
+++ b/CHEWBBACA/chewBBACA.py
@@ -376,7 +376,11 @@ def allele_call():
                         help='Convert legacy schemas to latest version.')
 
     parser.add_argument('--mode', type=int, required=False,
-                        choices=[1,2,3,4], default=4,
+                        choices=[1, 2, 3, 4], default=4,
+                        help='')
+
+    parser.add_argument('--speedup', required=False,
+                        action='store_true', dest='speedup',
                         help='')
 
     args = parser.parse_args()
@@ -406,6 +410,12 @@ def allele_call():
         args.translation_table = run_params['translation_table']
         args.minimum_length = run_params['minimum_locus_length']
         args.size_threshold = run_params['size_threshold']
+
+    if args.speedup is True:
+        print('Creating directory with pre-computed data to speedup '
+              'allele calling. Ignoring other options.')
+        AlleleCall.speedup(args.schema_directory, args.translation_table,
+                           args.cpu_cores)
 
     # create output directory
     created = fo.create_directory(args.output_directory)

--- a/CHEWBBACA/utils/constants.py
+++ b/CHEWBBACA/utils/constants.py
@@ -217,3 +217,7 @@ ALLELECALL_DICT = {'classification_files': None,
 
 GENOME_LIST = 'listGenomes2Call.txt'
 LOCI_LIST = 'listGenes2Call.txt'
+
+LOCI_LIST_FILE = '.genes_list'
+
+HASH_TABLE_MAXIMUM_ALLELES = 500000

--- a/CHEWBBACA/utils/core_functions.py
+++ b/CHEWBBACA/utils/core_functions.py
@@ -13,6 +13,7 @@ Code documentation
 
 import os
 import sys
+import math
 
 try:
     from utils import (constants as ct,
@@ -433,12 +434,13 @@ def cluster_sequences(sequences, word_size, window_size, clustering_sim,
                                                      sort_key=lambda x: len(x[1]),
                                                      reverse=True)}
 
-    if divide is True:
+    if divide is not None:
         # divide sequences into sublists
         # do not divide based on number of available cores as it may
         # lead to different results with different number of cores
-        cluster_inputs = im.split_iterable(sorted_seqs,
-                                           int(len(sorted_seqs)/40+10))
+        # divide into clusters with fixed number of sequences
+        cluster_inputs = im.split_iterable(sorted_seqs, divide)
+        print(len(cluster_inputs), len(cluster_inputs[0]))
     else:
         cluster_inputs = [sorted_seqs]
 


### PR DESCRIPTION
This PR adds changes to reduce runtime for small datasets. This is particularly important when users run chewBBACA as part of a pipeline that is parallelized to process a single strain per run. The main changes are the following:

- Creation of pre-computed hash tables with unique identifiers for each distinct allele in the schema to speedup exact matching at DNA and Protein levels. The hash table with unique identifiers for translated alleles avoids the schema translation step, which improves runtime, especially for large schemas.
- Translated coding sequences are divided into a number of groups equal to the number of available CPU cores for the clustering step. This reduces runtime but does increase peak memory usage.
- The alignment step that is used in mode 4 to classify the most divergent sequences and select new representative alleles processes groups of 100 representative alleles instead of using a per locus approach which represents a large overhead when processing small datasets.