### PR TITLE
print invalid names for simpler warnings which were skipped/missed

### DIFF
--- a/CHEWBBACA/PrepExternalSchema/adapt_schema.py
+++ b/CHEWBBACA/PrepExternalSchema/adapt_schema.py
@@ -458,6 +458,10 @@ def main(input_files, output_directories, cpu_cores, blast_score_ratio,
 
     print(f'\n\nNumber of invalid loci: {len(invalid_loci)}')
     print(f'Number of invalid alleles: {len(invalid_alleles)}')
+
+    print('\n\nNames of invalid loci: {0}'.format(' '.join(invalid_loci)))
+    print('Names of invalid alleles: {0}'.format(' '.join(invalid_alleles)))
+
     print('\nSuccessfully adapted {0}/{1} loci present in the '
           'input schema.'.format(len(genes_list)-len(invalid_loci),
                                  len(genes_list)))


### PR DESCRIPTION
Issue #189 https://github.com/B-UMMI/chewBBACA/issues/189 mentions some alleles and loci were ignored during the process to adapt a previously generated schema for chewie to use.

Printing the exact names would allow a user to quickly see what sequences (by name) to further interrogate as to why they might have been skipped.