### PR TITLE
Docs: Swap channel order for conda and mamba installation

### DIFF
--- a/CHEWBBACA/docs/user/getting_started/installation.rst
+++ b/CHEWBBACA/docs/user/getting_started/installation.rst
@@ -8,7 +8,7 @@ Install the latest released version using `conda <https://anaconda.org/bioconda/
 
 ::
 
-	conda create -c bioconda -c conda-forge -n chewie "chewbbaca=3.5.4"
+	conda create -c conda-forge -c bioconda -n chewie "chewbbaca=3.5.4"
 
 If you're having issues installing chewBBACA through conda, please verify that you are using
 conda>=22.11, and enable the libmamba solver, which might speed up the installation process.
@@ -16,7 +16,7 @@ You can also install `mamba <https://mamba.readthedocs.io/en/latest/index.html>`
 
 ::
 
-	mamba create -c bioconda -c conda-forge -n chewie "chewbbaca=3.5.4"
+	mamba create -c conda-forge -c bioconda -n chewie "chewbbaca=3.5.4"
 
 After creating the environment, you can use chewBBACA by activating the environment with the following command:
 


### PR DESCRIPTION
This prevents a dependency error for biopython.

```
❯ conda create -c bioconda -c conda-forge -n chewie2 "chewbbaca=3.5.4"                                                                                                                                                                                                                                
Channels:
 - bioconda
 - conda-forge
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - package chewbbaca-3.5.4-pyh106432d_0 requires biopython >=1.86, but none of the providers can be installed

Could not solve for environment specs
The following package could not be installed
└─ chewbbaca =3.5.4 * is not installable because it requires
   └─ biopython >=1.86 *, which conflicts with any installable versions previously reported.

```